### PR TITLE
Add "available bitrates"

### DIFF
--- a/share/quran-audio/authors.json
+++ b/share/quran-audio/authors.json
@@ -2,6 +2,7 @@
   "alafasy": {
     "name": "Mishari bin Rashed Alafasy",
     "nationality": "Kuwait",
+    "available_bitrates": [128, 64],
     "http": {
       "path": "/data/Alafasy_%{bitrate}kbps/"
     },
@@ -12,6 +13,7 @@
   "aziz_alili": {
     "name": "Aziz Alili",
     "nationality": "Macedonia",
+    "available_bitrates": [128],
     "http": {
       "path": "/data/aziz_alili_%{bitrate}kbps/"
     },
@@ -22,6 +24,7 @@
   "abdullah_awad_al_juhany": {
     "name": "Abdullah Awad Al Juhany",
     "nationality": "Saudi Arabia",
+    "available_bitrates": [128],
     "http": {
       "path": "/data/Abdullaah_3awwaad_Al-Juhaynee_%{bitrate}kbps/"
     },
@@ -32,6 +35,7 @@
   "ahmad_bin_ali_al_ajmi": {
     "name": "Ahmad bin Ali Al-Ajmi",
     "nationality": "Saudi Arabia",
+    "available_bitrates": [128],
     "http": {
       "path": "/data/ahmed_ibn_ali_al_ajamy_%{bitrate}kbps/"
     },

--- a/share/quran-audio/erb/author.erb
+++ b/share/quran-audio/erb/author.erb
@@ -1,3 +1,4 @@
 <%= Paint[author.name, :bold] %>
-From  <%= author.nationality %>
-CLI   --author <%= switch %>
+From       <%= author.nationality %>
+Bitrates   <%= author.available_bitrates.join(", ") %>
+CLI        --author <%= switch %>


### PR DESCRIPTION
Add "available_bitrates" property to authors.json, and show the bitrates in "quran-audio --pull authors" output.